### PR TITLE
Make size optional

### DIFF
--- a/lib/buckets/index.js
+++ b/lib/buckets/index.js
@@ -23,6 +23,10 @@ function normalize_time(config) {
       }
     });
 
+  if (typeof result.size === 'undefined') {
+    result.size = result.per_interval;
+  }
+
   return result;
 }
 


### PR DESCRIPTION
I think `size` is the less important parameter for the bucket, it allows configuring a property of the limit which is "burstiness" but in some (most?) of the cases you don't need this.

With this change If size is not specified assume the bucket's size is the same per_interval.

This allows configuring limitd as follows:

```yaml
buckets:
  ip:
    per_second: 10
```
Omitting the `size` parameter.
