### PR TITLE
Improve `STATUS` performance when using the redis backend

### DIFF
--- a/lib/db/redis/index.js
+++ b/lib/db/redis/index.js
@@ -8,21 +8,32 @@ var DRIP_AND_TAKE_LUA_SCRIPT = fs.readFileSync(path.join(__dirname, 'drip_and_ta
 // var TAKE_LUA_SCRIPT = fs.readFileSync(path.join(__dirname, 'take.lua'), 'utf8');
 var TAKE_FROM_FIXED_LUA_SCRIPT = fs.readFileSync(path.join(__dirname, 'take_from_fixed.lua'), 'utf8');
 
-function BucketDB (bucket_name, redis) {
+function BucketDB (bucket_name, redis, redis_subscriber) {
   this._redis = redis;
   this._bucket_name = bucket_name;
   this._index_name = 'bucketidx';
+
+  var self = this;
+  if (redis_subscriber && redis_subscriber.listenerCount && redis_subscriber.listenerCount('pmessage') === 0) {
+    redis_subscriber.on('pmessage', function(pattern, channel, message) {
+      if (channel.match(/:expired$/)) {
+        self.remove_from_index(message, _.noop);
+      }
+    });
+  }
 }
 
 BucketDB.prototype.add_or_update_index = function (key, callback) {
-  this._redis.zadd(this._index_name, 0, key).then(function() {
-    callback(key);
+  this._redis.zadd(this._index_name, 0, key).then(function(result_code) {
+    callback(key, result_code);
   });
 };
 
 BucketDB.prototype.remove_from_index = function (key, callback) {
-  this._redis.zrem(this._index_name, key).then(function() {
-    callback();
+  var prefix = this._redis.options && this._redis.options.keyPrefix;
+  prefix = prefix || '';
+  this._redis.zrem(this._index_name, key.replace(prefix, '')).then(function(result_code) {
+    callback(result_code);
   });
 };
 
@@ -145,9 +156,13 @@ module.exports = function (dbOptions) {
     numberOfKeys: 1
   });
 
+  // a subscriber needs to be in a different connection
+  var redis_subscriber = new Redis(dbOptions);
+  redis_subscriber.psubscribe('__key*__:*', _.noop);
+
   return {
     create: function (bucket_name) {
-      return new BucketDB(bucket_name, redis);
+      return new BucketDB(bucket_name, redis, redis_subscriber);
     }
   };
 };

--- a/lib/db/redis/index.js
+++ b/lib/db/redis/index.js
@@ -11,30 +11,55 @@ var TAKE_FROM_FIXED_LUA_SCRIPT = fs.readFileSync(path.join(__dirname, 'take_from
 function BucketDB (bucket_name, redis) {
   this._redis = redis;
   this._bucket_name = bucket_name;
+  this._index_name = 'bucketidx';
 }
 
+BucketDB.prototype.add_or_update_index = function (key, callback) {
+  this._redis.zadd(this._index_name, 0, key).then(function() {
+    callback(key);
+  });
+};
+
+BucketDB.prototype.remove_from_index = function (key, callback) {
+  this._redis.zrem(this._index_name, key).then(function() {
+    callback();
+  });
+};
+
 BucketDB.prototype.drip_and_take = function (key, params, count, callback) {
-  this._redis.drip_and_take(this._bucket_name + ':' + key, +new Date(), params.per_interval / params.interval, params.size, count, function (err, result) {
-    if (err) return callback(err);
-    return callback(null, !!result[2], {
-      lastDrip: parseInt(result[0], 10),
-      content:  parseInt(result[1], 10),
-      size:     params.size
+  var self = this;
+  self.add_or_update_index(this._bucket_name + ':' + key, function (key) {
+    self._redis.drip_and_take(key, +new Date(), params.per_interval / params.interval, params.size, count, function (err, result) {
+      if (err) return callback(err);
+      callback(null, !!result[2], {
+        lastDrip: parseInt(result[0], 10),
+        content:  parseInt(result[1], 10),
+        size:     params.size
+      });
     });
   });
 };
 
 BucketDB.prototype.take_from_fixed = function (key, params, count, callback) {
-  this._redis.take_from_fixed(this._bucket_name + ':' + key, params.size, count, function (err, result) {
-    if (err) return callback(err);
-    callback(null, result);
+  var self = this;
+  self.add_or_update_index(this._bucket_name + ':' + key, function (key) {
+    self._redis.take_from_fixed(key, params.size, count, function (err, result) {
+      if (err) return callback(err);
+      callback(null, result);
+    });
   });
 };
 
 BucketDB.prototype.get = function (key, callback) {
   var redis_key = this._bucket_name + ':' + key;
+  var self = this;
 
-  return this._redis.get(redis_key, function (err, value) {
+  return self._redis.get(redis_key, function (err, value) {
+    if (!err && !value) {
+      return self.remove_from_index(redis_key, function() {
+        callback(err);
+      });
+    }
     if (err || !value) {
       return callback(err);
     }
@@ -47,20 +72,9 @@ BucketDB.prototype.list = function (key, callback) {
   var self = this;
   var prefix = self._redis.options && self._redis.options.keyPrefix;
 
-  if (prefix) {
-    redis_key = prefix + redis_key;
-  }
+  this._redis.zrangebylex(this._index_name, '[' + redis_key, '[' + redis_key + '\xff', function(err, keys) {
+    if (err) return callback(err);
 
-  var stream = self._redis.scanStream({
-    match: redis_key + '*',
-    count: 1000
-  });
-
-  var keys = [];
-
-  stream.on('data', function (k) {
-    keys = keys.concat(k);
-  }).once('end', function () {
     keys = !prefix ? keys : keys.map(function (key) {
                               return key.replace(prefix, '');
                             });
@@ -108,7 +122,7 @@ BucketDB.prototype.list = function (key, callback) {
       callback(null, result);
     });
 
-  }).once('error', callback);
+  });
 };
 
 


### PR DESCRIPTION
Improve `STATUS` performance using `zrangebylex` instead of `scan` in the redis backend. To be able to use `zrangebylex` we add keys to a secondary index whenever we `TAKE` or `PUT` in a bucket and use a redis pub/sub client to remove keys from the index whenever a key is expired.

One caveat: if limitd is down when redis publishes the expiration event, the event will be lost and the key will stay in the index until a second expiration event causes its removal.

Fixes #36.