### PR TITLE
Collect and send metrics using auth0-instrumentation

### DIFF
--- a/lib/handlers/ping.js
+++ b/lib/handlers/ping.js
@@ -1,5 +1,6 @@
 var Response = require('../../messages/protocol_buffers').Response;
 var PongResponse = require('../../messages/protocol_buffers').PongResponse;
+var agent = require('auth0-instrumentation');
 
 function build_pong_response (protocol, message) {
   if (protocol === 'protocol-buffers') {
@@ -16,6 +17,8 @@ function build_pong_response (protocol, message) {
 }
 
 module.exports.handle = function (buckets, log, protocol, message, done) {
+  agent.metrics.increment('requests.incoming.ping');
+
   log.info({
     method:     'PING',
     'type':     message['type'],
@@ -24,6 +27,9 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
     all:        message.all,
   }, 'PING');
 
-
-  setImmediate(done, null, build_pong_response(protocol, message));
+  var start = new Date();
+  var result = build_pong_response(protocol, message);
+  agent.metrics.increment('requests.processed.ping');
+  agent.metrics.histogram('requests.processed.ping.time', (new Date() - start));
+  setImmediate(done, null, result);
 };

--- a/lib/handlers/put.js
+++ b/lib/handlers/put.js
@@ -1,5 +1,6 @@
 var Response = require('../../messages/protocol_buffers').Response;
 var PutResponse = require('../../messages/protocol_buffers').PutResponse;
+var agent = require('auth0-instrumentation');
 
 function build_put_response (protocol, message, bucket) {
   if (protocol === 'protocol-buffers') {
@@ -33,6 +34,8 @@ function build_put_response (protocol, message, bucket) {
 }
 
 module.exports.handle = function (buckets, log, protocol, message, done) {
+  agent.metrics.increment('requests.incoming.put');
+
   var bucket_type = buckets.get(message['type']);
 
   log.debug({
@@ -46,6 +49,8 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
 
   bucket_type.putToken(message.key, message.all || message.count, function (err, bucket) {
     if (err) {
+      agent.metrics.increment('requests.processed.put');
+      agent.metrics.histogram('requests.processed.put.time', (new Date() - start));
       return log.error({
         err:    err,
         method: 'PUT',
@@ -71,7 +76,8 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
     }, 'PUT/RESET');
 
     var result = build_put_response (protocol, message, bucket);
-
+    agent.metrics.increment('requests.processed.put');
+    agent.metrics.histogram('requests.processed.put.time', (new Date() - start));
     done(null, result);
   });
 };

--- a/lib/handlers/status.js
+++ b/lib/handlers/status.js
@@ -1,5 +1,6 @@
 var Response = require('../../messages/protocol_buffers').Response;
 var StatusResponse = require('../../messages/protocol_buffers').StatusResponse;
+var agent = require('auth0-instrumentation');
 
 function build_status_response (protocol, message, items) {
   if (protocol === 'protocol-buffers') {
@@ -41,6 +42,8 @@ function build_status_response (protocol, message, items) {
 }
 
 module.exports.handle = function (buckets, log, protocol, message, done) {
+  agent.metrics.increment('requests.incoming.status');
+
   var bucket_type = buckets.get(message['type']);
 
   log.info({
@@ -54,7 +57,9 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
 
   bucket_type.status(message.key, function (err, items) {
     if (err) {
-      log.error({
+      agent.metrics.increment('requests.processed.status');
+      agent.metrics.histogram('requests.processed.status.time', (new Date() - start));
+      return log.error({
         method:     'STATUS',
         'type':     message['type'],
         key:        message.key,
@@ -71,7 +76,8 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
     }, 'STATUS');
 
     var result = build_status_response(protocol, message, items);
-
+    agent.metrics.increment('requests.processed.status');
+    agent.metrics.histogram('requests.processed.status.time', (new Date() - start));
     done(null, result);
   });
 };

--- a/lib/handlers/take.js
+++ b/lib/handlers/take.js
@@ -1,5 +1,6 @@
 var Response = require('../../messages/protocol_buffers').Response;
 var TakeResponse = require('../../messages/protocol_buffers').TakeResponse;
+var agent = require('auth0-instrumentation');
 
 function build_take_response (protocol, message, conformant, bucket) {
   if (protocol === 'protocol-buffers') {
@@ -34,6 +35,8 @@ function build_take_response (protocol, message, conformant, bucket) {
 }
 
 module.exports.handle = function (buckets, log, protocol, message, done) {
+  agent.metrics.increment('requests.incoming.take');
+
   var bucket_type = buckets.get(message['type']);
 
   log.debug({
@@ -47,6 +50,8 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
 
   bucket_type.removeToken(message.key, message.count, function (err, conformant, bucket) {
     if (err) {
+      agent.metrics.increment('requests.processed.take');
+      agent.metrics.histogram('requests.processed.take.time', (new Date() - start));
       return log.error({
         err:    err,
         method: 'TAKE',
@@ -70,6 +75,9 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
       took:       new Date() - start
     }, 'TAKE');
 
-    done(null, build_take_response(protocol, message, conformant, bucket));
+    var result = build_take_response(protocol, message, conformant, bucket);
+    agent.metrics.increment('requests.processed.take');
+    agent.metrics.histogram('requests.processed.take.time', (new Date() - start));
+    done(null, result);
   });
 };

--- a/lib/handlers/wait.js
+++ b/lib/handlers/wait.js
@@ -1,5 +1,6 @@
 var Response = require('../../messages/protocol_buffers').Response;
 var TakeResponse = require('../../messages/protocol_buffers').TakeResponse;
+var agent = require('auth0-instrumentation');
 
 function build_wait_response (protocol, message, delayed, bucket) {
   if (protocol === 'protocol-buffers') {
@@ -36,6 +37,8 @@ function build_wait_response (protocol, message, delayed, bucket) {
 }
 
 module.exports.handle = function (buckets, log, protocol, message, done) {
+  agent.metrics.increment('requests.incoming.wait');
+
   var bucket_type = buckets.get(message['type']);
 
   log.debug({
@@ -72,6 +75,8 @@ module.exports.handle = function (buckets, log, protocol, message, done) {
     }, 'WAIT');
 
     var result = build_wait_response(protocol, message, delayed, bucket);
+    agent.metrics.increment('requests.processed.wait');
+    agent.metrics.histogram('requests.processed.take.time', (new Date() - since));
     done(null, result);
   });
 };

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
+    "auth0-instrumentation": "github:auth0/auth0-instrumentation#v0.0.15",
     "avsc": "~3.1.2",
     "bunyan": "~1.3.3",
     "commander": "~2.6.0",


### PR DESCRIPTION
If the config variable `metrics_api_key` is present, use it to send metrics to DataDog using `auth0-instrumentation`.