### PR TITLE
Update package.json to actually remove warning on installs for node@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "license": "MIT",
   "engines": {
-    "node": ">=0.12 <4"
+    "node": ">=0.12 <5"
   },
   "dependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
```
npm WARN engine limitd@4.17.2: wanted: {"node":">=0.12 <4"} (current: {"node":"4.4.3","npm":"2.15.1"})
```