### PR TITLE
add a new option: unlimited

### DIFF
--- a/lib/buckets/bucket.js
+++ b/lib/buckets/bucket.js
@@ -42,7 +42,7 @@ BucketType.prototype._getResetTimestamp = function (bucket, params) {
     return 0;
   }
 
-  var now = new Date().getTime();
+  var now = Date.now();
   var missing = params.size - bucket.content;
   var msToCompletion = Math.ceil(missing * params.interval / params.per_interval);
 
@@ -59,7 +59,7 @@ BucketType.prototype._getParams = function (instance) {
                         })[0];
 
   if (override && (!override.until || override.until > new Date())) {
-    return _.extend(_.pick(this._options, ['per_interval', 'interval', 'size']), override);
+    return _.extend(_.pick(this._options, ['per_interval', 'interval', 'size', 'unlimited']), override);
   }
 
   return this._options;
@@ -68,6 +68,15 @@ BucketType.prototype._getParams = function (instance) {
 BucketType.prototype.removeToken = function (instance, count, done) {
   var self = this;
   var params = this._getParams(instance);
+
+  if (params.unlimited) {
+    return setImmediate(done, null, true, {
+      lastDrip: Date.now(),
+      content:  params.size,
+      reset:    Math.floor(Date.now() / MILLISECONDS_PER_SECOND),
+      size:     params.size
+    });
+  }
 
   if (!params.per_interval && self._db.take_from_fixed) {
     return self._db.take_from_fixed(instance, params, count, function (err, content) {

--- a/test/fixture/fixture.yml
+++ b/test/fixture/fixture.yml
@@ -7,6 +7,10 @@ buckets:
     size: 10
     per_second: 5
     override:
+      0.0.0.0:
+        size: 100
+        unlimited: true
+
       127.0.0.1:
         size: 1000
         per_second: 500

--- a/test/server.tests.js
+++ b/test/server.tests.js
@@ -230,6 +230,20 @@ function run_tests (db_options) {
         done();
       });
     });
+
+    it('should work for unlimited', function (done) {
+      var now = 1425920267;
+      MockDate.set(now * 1000);
+      client.take('ip', '0.0.0.0', function (err, response) {
+        if (err) return done(err);
+        assert.ok(response.conformant);
+        assert.equal(response.remaining, 100);
+        assert.equal(response.reset, now);
+        assert.equal(response.limit, 100);
+        done();
+      });
+    });
+
   });
 
   describe('WAIT', function () {
@@ -378,6 +392,19 @@ function run_tests (db_options) {
         client.status('ip', ip, function (err, response) {
           if (err) return done(err);
           assert.equal(response.items[0].remaining, 9);
+          done();
+        });
+      });
+    });
+
+    it('should work for unlimited', function (done) {
+      var now = 1425920267;
+      MockDate.set(now * 1000);
+      client.take('ip', '0.0.0.0', function (err) {
+        if (err) return done(err);
+        client.status('ip', '0.0.0.0', function (err, response) {
+          if (err) return done(err);
+          assert.equal(response.items.length, 0);
           done();
         });
       });


### PR DESCRIPTION
Some times it make sense to completely disable a limit on an override. 

This PR adds this syntax:

```yaml
 buckets:
   ip:
     size: 10
     per_second: 5
     override:
      0.0.0.0:
        size: 100
        unlimited: true
```


In this case when doing a `TAKE` on `ip` - `0.0.0.0`, we are not even going to the database. Instead we return

```
{
  "conformant": true,
  "reset": now,
  "limit": size,
  "remaining": size
}
```

